### PR TITLE
further refactorings for client module

### DIFF
--- a/src/fastapi_redis_cache/client.py
+++ b/src/fastapi_redis_cache/client.py
@@ -12,7 +12,7 @@ from fastapi_redis_cache.redis import redis_connect
 from fastapi_redis_cache.util import deserialize_json, serialize_json
 
 DEFAULT_RESPONSE_HEADER = "X-FastAPI-Cache"
-DEFAULT_ALLOWED_TYPES = ["GET"]
+ALLOWED_HTTP_TYPES = ["GET"]
 ONE_YEAR_IN_SECONDS = 31535990
 LOG_TIMESTAMP = "%m/%d/%Y %I:%M:%S %p"
 HTTP_TIME = "%a, %d %b %Y %H:%M:%S GMT"
@@ -51,9 +51,9 @@ class FastApiRedisCache(metaclass=MetaSingleton):
     def not_connected(self):
         return not self.connected
 
-    def connect(
+    def init(
         self,
-        host_url: RedisDsn,
+        host_url: str,
         prefix: Optional[str] = None,
         response_header: Optional[str] = None,
         allow_request_types: List[str] = None,
@@ -62,16 +62,20 @@ class FastApiRedisCache(metaclass=MetaSingleton):
         """Connect to a Redis database using `host_url` and configure cache settings.
 
         Args:
-            host_url (RedisDsn): [description]
-            prefix (str, optional): [description]. Defaults to None.
-            response_header (Optional[str], optional): [description]. Defaults to None.
-            allow_request_types (List[str], optional): [description]. Defaults to None.
-            ignore_arg_types (Optional[List[Type[object]]], optional): [description]. Defaults to None.
+            host_url (str): URL for a Redis database.
+            prefix (str, optional): Prefix to add to every cache key stored in the
+                Redis database. Defaults to None.
+            response_header (str, optional): Name of the custom header field used to
+                identify cache hits/misses. Defaults to None.
+            ignore_arg_types (List[Type[object]], optional): Each argument to the
+                API endpoint function is used to compose the cache key. If there
+                are any arguments that have no effect on the response (such as a
+                `Request` or `Response` object), including their type in this list
+                will ignore those arguments when the key is created. Defaults to None.
         """
         self.host_url = host_url
         self.prefix = prefix
         self.response_header = response_header or DEFAULT_RESPONSE_HEADER
-        self.allow_request_types = allow_request_types or DEFAULT_ALLOWED_TYPES
         self.ignore_arg_types = ignore_arg_types
         self._connect()
 
@@ -87,7 +91,7 @@ class FastApiRedisCache(metaclass=MetaSingleton):
 
     def request_is_not_cacheable(self, request: Request) -> bool:
         return request and (
-            request.method not in self.allow_request_types
+            request.method not in ALLOWED_HTTP_TYPES
             or any(directive in request.headers.get("Cache-Control", "") for directive in ["no-store", "no-cache"])
         )
 
@@ -101,7 +105,7 @@ class FastApiRedisCache(metaclass=MetaSingleton):
             self.log(RedisEvent.KEY_FOUND_IN_CACHE, key=key)
         return (ttl, in_cache)
 
-    def requested_resource_not_modified(self, request: Request, cached_data: Union[str, Dict]) -> bool:
+    def requested_resource_not_modified(self, request: Request, cached_data: str) -> bool:
         if not request or "If-None-Match" not in request.headers:
             return False
         check_etags = [etag.strip() for etag in request.headers["If-None-Match"].split(",") if etag]
@@ -117,14 +121,14 @@ class FastApiRedisCache(metaclass=MetaSingleton):
             self.log(RedisEvent.FAILED_TO_CACHE_KEY, key=key, value=value)
 
     def set_response_headers(
-        self, response: Response, cache_hit: bool, response_data: str = None, ttl: int = None
+        self, response: Response, cache_hit: bool, response_data: Dict = None, ttl: int = None
     ) -> None:
         response.headers[self.response_header] = "Hit" if cache_hit else "Miss"
         expires_at = datetime.utcnow() + timedelta(seconds=ttl)
         response.headers["Expires"] = expires_at.strftime(HTTP_TIME)
         response.headers["Cache-Control"] = f"max-age={ttl}"
         response.headers["ETag"] = self.get_etag(response_data)
-        if "last_modified" in response_data:
+        if "last_modified" in response_data:  # pragma: no cover
             response.headers["Last-Modified"] = response_data["last_modified"]
 
     def log(self, event: RedisEvent, msg: Optional[str] = None, key: Optional[str] = None, value: Optional[str] = None):
@@ -148,8 +152,10 @@ class FastApiRedisCache(metaclass=MetaSingleton):
 
     @staticmethod
     def get_etag(cached_data: Union[str, Dict]) -> str:
-        if not isinstance(cached_data, str):
-            cached_data = str(cached_data)
+        if isinstance(cached_data, dict):
+            cached_data = serialize_json(cached_data)
+        if isinstance(cached_data, bytes):
+            cached_data = cached_data.decode()
         return f"W/{hash(cached_data)}"
 
     @staticmethod


### PR DESCRIPTION
- rename connect method to init
- remove allowed_types attribute, this is no longer configuragle
  - only GET requests are cacheable