### PR TITLE
Add functionality for specifying a web cache expiration

### DIFF
--- a/src/fastapi_redis_cache/version.py
+++ b/src/fastapi_redis_cache/version.py
@@ -1,3 +1,3 @@
 # flake8: noqa
-__version_info__ = ("0", "2", "5")  # pragma: no cover
+__version_info__ = ("0", "3", "0")  # pragma: no cover
 __version__ = ".".join(__version_info__)  # pragma: no cover

--- a/tests/main.py
+++ b/tests/main.py
@@ -34,8 +34,18 @@ def cache_json_encoder():
 
 @app.get("/cache_one_hour")
 @cache_one_hour()
-def partial_cache_one_hour(response: Response):
+def cache_one_hour(response: Response):
     return {"success": True, "message": "this data should be cached for one hour"}
+
+
+REDIS_EXPIRE_SECONDS = 10
+WEB_EXPIRE_SECONDS = 5
+
+
+@app.get("/cache_web_expires_before_redis")
+@cache(expire=REDIS_EXPIRE_SECONDS, web_expire=WEB_EXPIRE_SECONDS)
+async def cache_web_expires_before_redis(request: Request, response: Response):
+    return {"success": True, "message": "this data should be web cached for five seconds"}
 
 
 @app.get("/cache_invalid_type")


### PR DESCRIPTION
It should be possible to use the `cache-control` header's `no-cache` directive to force web caches to revalidate cached results before providing them. Unfortunately, some proxy caches do not appear to respect `no-cache`, and will continue to provide results from cache until they have expired.

This commit allows the Redis and web cache expirations to be set independently, so that items can be cached to Redis with long expirations, but provided to the web with shorter expirations, forcing web caches to revalidate.